### PR TITLE
Fix Vue warning about invalid prop type

### DIFF
--- a/src/main/js/bundles/dn_printingenhanced/LayoutWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/LayoutWidget.vue
@@ -101,7 +101,7 @@
                 v-if="scaleValues.length && visibleUiElements.scale"
                 md12>
                 <v-select
-                    v-model="scaleValue"
+                    v-model.number="scaleValue"
                     :items="scaleValues"
                     :label="i18n.scale"
                     :disabled="!scaleEnabled"
@@ -112,7 +112,7 @@
                 v-if="!scaleValues.length && visibleUiElements.scale"
                 md10>
                 <v-text-field
-                    v-model="scaleValue"
+                    v-model.number="scaleValue"
                     :label="i18n.scale"
                     :disabled="!scaleEnabled"
                     step="1"


### PR DESCRIPTION
Force scaleValue v-model type to number (was string implicitly).

This case occurs when no Config option for `scaleValues` is set and the respective input field becomes a HTML number type field (with up/down stepper).