### PR TITLE
Fix printing extent and preview handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
     <build>
         <pluginManagement>
             <plugins>
+              <plugin>
+                    <groupId>de.conterra.mapapps</groupId>
+                    <artifactId>mapapps-maven-plugin</artifactId>
+                    <version>${mapapps.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>de.conterra.jsregistry</groupId>
                     <artifactId>ct-jsregistry-maven-plugin</artifactId>

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
@@ -241,18 +241,6 @@
                     }
                     this.layout = "MAP_ONLY";
                 }
-            },
-            scaleEnabled: function(scaleEnabled) {
-                if (scaleEnabled === false) {
-                    this.printPreviewInitallyVisible = this.enablePrintPreview;
-                    this.enablePrintPreview = false;
-                    this.$emit('resetPrintGeometry');
-                }
-                if (scaleEnabled && !this.visibleUiElements.printPreviewCheckbox) {
-                    if (this.printPreviewInitallyVisible === true) {
-                        this.enablePrintPreview = this.printPreviewInitallyVisible;
-                    }
-                }
             }
         },
         mounted: function () {

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
@@ -244,10 +244,14 @@
             },
             scaleEnabled: function(scaleEnabled) {
                 if (scaleEnabled === false) {
+                    this.printPreviewInitallyVisible = this.enablePrintPreview;
                     this.enablePrintPreview = false;
+                    this.$emit('resetPrintGeometry');
                 }
                 if (scaleEnabled && !this.visibleUiElements.printPreviewCheckbox) {
-                    this.enablePrintPreview = this.printPreviewInitallyVisible;
+                    if (this.printPreviewInitallyVisible === true) {
+                        this.enablePrintPreview = this.printPreviewInitallyVisible;
+                    }
                 }
             }
         },
@@ -256,9 +260,6 @@
                 this.activeTab = 1;
             } else {
                 this.activeTab = 0;
-            }
-            if (!this.visibleUiElements.printPreviewCheckbox) {
-                this.printPreviewInitallyVisible = this.enablePrintPreview;
             }
             this.$emit('startup');
         },

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
@@ -26,7 +26,7 @@ export default class PrintingEnhancedWidgetFactory {
     }
 
     createInstance() {
-        return new VueDijit(this.vm, {class: "printing-enhanced-widget"});
+        return new VueDijit(this.vm, { class: "printing-enhanced-widget" });
     }
 
     _initComponent() {
@@ -88,7 +88,7 @@ export default class PrintingEnhancedWidgetFactory {
             "legendEnabled": false,
             "attributionEnabled": false
         };
-        vm.visibleUiElements = {...defaultVisibleUiElements, ...properties.visibleUiElements};
+        vm.visibleUiElements = { ...defaultVisibleUiElements, ...properties.visibleUiElements };
         vm.dpiValues = properties.dpiValues;
         vm.scaleValues = properties.scaleValues;
         // listen to view model methods
@@ -98,13 +98,22 @@ export default class PrintingEnhancedWidgetFactory {
         vm.$on('resetScale', () => {
             esriPrintWidget._resetToCurrentScale();
         });
-        vm.$on('resetPrintGeometry', () => {
-            esriPrintWidget._resetToCurrentScale();
-            this._eventService.postEvent("dn_printingenhanced/RESETPRINTGEOMETRY");
-        });
 
         Binding.for(vm, printingPreviewController)
-            .syncAll("enablePrintPreview")
+            .syncToRight("enablePrintPreview", "drawPrintPreview", (enablePrintPreview) => {
+                if (enablePrintPreview && vm.scaleEnabled) {
+                    return true;
+                } else {
+                    return false;
+                }
+            })
+            .syncToRight("scaleEnabled", "drawPrintPreview", (scaleEnabled) => {
+                if (scaleEnabled && vm.enablePrintPreview) {
+                    return true;
+                } else {
+                    return false;
+                }
+            })
             .enable()
             .syncToLeftNow();
 

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
@@ -98,6 +98,10 @@ export default class PrintingEnhancedWidgetFactory {
         vm.$on('resetScale', () => {
             esriPrintWidget._resetToCurrentScale();
         });
+        vm.$on('resetPrintGeometry', () => {
+            esriPrintWidget._resetToCurrentScale();
+            this._eventService.postEvent("dn_printingenhanced/RESETPRINTGEOMETRY");
+        });
 
         Binding.for(vm, printingPreviewController)
             .syncAll("enablePrintPreview")

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
@@ -91,6 +91,7 @@ export default class PrintingEnhancedWidgetFactory {
         vm.visibleUiElements = { ...defaultVisibleUiElements, ...properties.visibleUiElements };
         vm.dpiValues = properties.dpiValues;
         vm.scaleValues = properties.scaleValues;
+        vm.enablePrintPreview = properties.enablePrintPreview;
         // listen to view model methods
         vm.$on('print', () => {
             esriPrintWidget._handlePrintMap();

--- a/src/main/js/bundles/dn_printingenhanced/PrintingPreviewController.js
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingPreviewController.js
@@ -142,6 +142,11 @@ export default declare({
         this._printRotation = this._computeAngle(geometry.rings[0][0], geometry.rings[0][1]);
     },
 
+    resetPrintGeometry() {
+        this._printExtent = null;
+        this._printRotation = null;
+    },
+
     setPrintingToggleTool(tool) {
         this._printingToggleTool = tool;
         const connect = this[_connect] = new Connect();

--- a/src/main/js/bundles/dn_printingenhanced/manifest.json
+++ b/src/main/js/bundles/dn_printingenhanced/manifest.json
@@ -112,10 +112,6 @@
                     {
                         "topic": "dn_printingenhanced/PRINTSETTINGS",
                         "method": "setPrintSettings"
-                    },
-                    {
-                        "topic": "dn_printingenhanced/RESETPRINTGEOMETRY",
-                        "method": "resetPrintGeometry"
                     }
                 ]
             },
@@ -333,10 +329,6 @@
                 {
                     "name": "_printingEnhancedProperties",
                     "providing": "dn_printingenhanced.PrintingEnhancedProperties"
-                },
-                {
-                    "name": "_eventService",
-                    "providing": "ct.framework.api.EventService"
                 }
             ]
         },

--- a/src/main/js/bundles/dn_printingenhanced/manifest.json
+++ b/src/main/js/bundles/dn_printingenhanced/manifest.json
@@ -112,6 +112,10 @@
                     {
                         "topic": "dn_printingenhanced/PRINTSETTINGS",
                         "method": "setPrintSettings"
+                    },
+                    {
+                        "topic": "dn_printingenhanced/RESETPRINTGEOMETRY",
+                        "method": "resetPrintGeometry"
                     }
                 ]
             },
@@ -329,6 +333,10 @@
                 {
                     "name": "_printingEnhancedProperties",
                     "providing": "dn_printingenhanced.PrintingEnhancedProperties"
+                },
+                {
+                    "name": "_eventService",
+                    "providing": "ct.framework.api.EventService"
                 }
             ]
         },


### PR DESCRIPTION
Fixed the following issues using code from @njakuschona:

Druckbereich entspricht nicht der Bildschirmdarstellung
[Workflow: Starten mit "scaleEnabled": true, Hineinzoomen 1:4000, Druckdialog öffnen, Maßstab festlegen deaktivieren ("scale": 1000 voreingestellt), Druck erstellen]

Druckrahmen wird nicht angezeigt
[Workflow: Starten mit "scaleEnabled": false, Hineinzoomen 1:4000, Druckdialog öffnen, Maßstab festlegen aktivieren (Druckrahmen wird nicht dargestellt), Druck wird aber richtig erstellt]
