### PR TITLE
A11y improvements

### DIFF
--- a/src/main/js/bundles/dn_printingenhanced/MapOnlyWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/MapOnlyWidget.vue
@@ -90,14 +90,24 @@
                 v-if="visibleUiElements.widthAndHeight"
                 md2
             >
-                <v-btn
-                    flat
-                    icon
-                    color="primary"
-                    @click="rotate"
+                <v-tooltip
+                    top
+                    open-delay="800"
                 >
-                    <v-icon>rotate_90_degrees_ccw</v-icon>
-                </v-btn>
+                    <template #activator="{ on }">
+                        <v-btn
+                            flat
+                            icon
+                            color="primary"
+                            :aria-label="i18n.rotatePrintFrame"
+                            v-on="on"
+                            @click="rotate"
+                        >
+                            <v-icon>rotate_90_degrees_ccw</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>{{ i18n.rotatePrintFrame }}</span>
+                </v-tooltip>
             </v-flex>
             <v-flex
                 v-if="visibleUiElements.printPreviewCheckbox"

--- a/src/main/js/bundles/dn_printingenhanced/PrintingResultsWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingResultsWidget.vue
@@ -37,15 +37,22 @@
                         indeterminate
                         size="22"
                         color="primary"
+                        role="alert"
+                        aria-busy="true"
+                        :aria-label="i18n.printResultLoading"
                     />
                     <v-icon
                         v-else-if="exportedLink.error"
                         color="red"
+                        role="alert"
+                        :aria-label="i18n.printError"
                     >
                         error
                     </v-icon>
                     <v-icon
                         v-else
+                        role="alert"
+                        :aria-label="`${exportedLink.name} ${i18n.printResultAvailable}`"
                     >
                         cloud_download
                     </v-icon>

--- a/src/main/js/bundles/dn_printingenhanced/nls/bundle.js
+++ b/src/main/js/bundles/dn_printingenhanced/nls/bundle.js
@@ -45,6 +45,9 @@ module.exports = {
             dpi: "Quality",
             showPrintPreview: "Show print preview",
             printResults: "Results",
+            printResultLoading: "Print result is loading",
+            printError: "An error occurred while loading the print result",
+            printResultAvailable: ": print result is available",
             noPrintResults: "No print results",
             errors: {
                 unknown: "Printing: An unknown error occurred!",

--- a/src/main/js/bundles/dn_printingenhanced/nls/bundle.js
+++ b/src/main/js/bundles/dn_printingenhanced/nls/bundle.js
@@ -37,6 +37,7 @@ module.exports = {
             copyrightPlaceholder: "Copyright",
             width: "Width",
             height: "Height",
+            rotatePrintFrame: "Rotate print frame",
             scale: "Scale",
             scaleEnabled: "Set scale",
             legendEnabled: "Enable legend",

--- a/src/main/js/bundles/dn_printingenhanced/nls/de/bundle.js
+++ b/src/main/js/bundles/dn_printingenhanced/nls/de/bundle.js
@@ -45,6 +45,9 @@ module.exports = {
         dpi: "Qualität",
         showPrintPreview: "Druckrahmen anzeigen",
         printResults: "Ergebnisse",
+        printResultLoading: "Druckergebnis wird geladen",
+        printError: "Es ist ein Fehler beim Laden des Druckergebnisses aufgetreten",
+        printResultAvailable: ": Druckergebnis ist verfügbar",
         noPrintResults: "Keine Druckergebnisse vorhanden",
         errors: {
             unknown: "Drucken: Ein unbekannter Fehler ist aufgetreten!",

--- a/src/main/js/bundles/dn_printingenhanced/nls/de/bundle.js
+++ b/src/main/js/bundles/dn_printingenhanced/nls/de/bundle.js
@@ -37,6 +37,7 @@ module.exports = {
         copyrightPlaceholder: "Urheberrecht",
         width: "Breite",
         height: "Höhe",
+        rotatePrintFrame: "Druckrahmen drehen",
         scale: "Maßstab",
         scaleEnabled: "Maßstab festlegen",
         legendEnabled: "Legende einbeziehen",


### PR DESCRIPTION
- "Druckrahmen Drehen" Icon-Button: aria-label und Tooltip hinzugefügt
- Feedbackergänzt, dass der Druck lädt und fertig ist bzw. einen Fehler ausgibt