### PR TITLE
Show error when PrintViewModel could not be loaded

### DIFF
--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidget.vue
@@ -16,7 +16,12 @@
 
 -->
 <template>
+    <v-container v-if="error">
+        <!-- show error to user -->
+        {{ error }}
+    </v-container>
     <v-container
+        v-else
         grid-list-md
         fluid
         class="pa-0 fullHeight printing-enhanced-container"
@@ -178,7 +183,8 @@
                 width: 800,
                 enablePrintPreview: true,
                 printPreviewInitallyVisible: null,
-                activeTab: 0
+                activeTab: 0,
+                error: ""
             };
         },
         watch: {

--- a/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
+++ b/src/main/js/bundles/dn_printingenhanced/PrintingEnhancedWidgetFactory.js
@@ -97,6 +97,17 @@ export default class PrintingEnhancedWidgetFactory {
         return widget;
     }
 
+    /**
+     * @param {__esri.PrintViewModel} viewmodel
+     * @param {() => void} callback}
+     */
+    #callAfterLoading(viewmodel, callback) {
+        if (viewmodel.state !== "initializing") {
+            return callback();
+        }
+        return viewmodel.load().then(() => callback());
+    }
+
     _initComponent() {
         const properties = this._printingEnhancedProperties;
         const vm = this.vm = new Vue(PrintingEnhancedWidget);
@@ -104,16 +115,17 @@ export default class PrintingEnhancedWidgetFactory {
         const esriPrintWidget = printWidget._esriWidget;
         const printViewModel = esriPrintWidget.viewModel;
 
-        if (printViewModel.templatesInfo) {
-            this._setTemplatesInfos(printViewModel.templatesInfo);
-        } else {
-            console.info("templatesInfo not yet available. Did you configure the property 'printtask.service.url` in map.apps' application.properties file? Still waiting for templatesInfo to get available...");
-            const watcher = printViewModel.watch("templatesInfo", (templatesInfo) => {
-                console.info("templatesInfo now available.");
-                this._setTemplatesInfos(templatesInfo);
-                watcher.remove();
-            });
-        }
+        this.#callAfterLoading(printViewModel, () => {
+            if (printViewModel.error) {
+                vm.error = `${printViewModel.error.message}`;
+                return;
+            }
+
+            if (!printViewModel.templatesInfo) {
+                vm.error = "templatesInfo not available. Did you configure the property 'printtask.service.url` in map.apps' application.properties file? Still waiting for templatesInfo to get available...";
+                return;
+            }
+        });
 
         vm.i18n = this._i18n.get().ui;
         vm.exportedItems = [];


### PR DESCRIPTION
A bug in ArcGIS Enterprise 11.3 and 11.4 causes the PrintViewModel (and -Widget) to not work properly.
Since it is the base for this bundle, it would be nice to inform the user, that the current environment is not working.

This change handles the loading and shows the message to the user.

For further information to the ArcGIS Enterprise bug see:
https://community.esri.com/t5/arcgis-experience-builder-questions/print-service-issue/td-p/1597421